### PR TITLE
RoutingRequestSpec.address(...) updates hasRoutingMetadata

### DIFF
--- a/rsocket-routing-client-spring/src/main/java/io/rsocket/routing/client/spring/RoutingRSocketRequester.java
+++ b/rsocket-routing-client-spring/src/main/java/io/rsocket/routing/client/spring/RoutingRSocketRequester.java
@@ -215,7 +215,7 @@ public final class RoutingRSocketRequester implements RSocketRequester {
 		}
 
 		public RoutingRequestSpec address(String serviceName) {
-			delegate.metadata(spec -> {
+			metadata(spec -> {
 				Address address = Address.from(properties.getRouteId())
 						.with(WellKnownKey.SERVICE_NAME, serviceName).build();
 				spec.metadata(address, MimeTypes.ROUTING_FRAME_MIME_TYPE);
@@ -224,7 +224,7 @@ public final class RoutingRSocketRequester implements RSocketRequester {
 		}
 
 		public RoutingRequestSpec address(Consumer<Address.Builder> builderConsumer) {
-			delegate.metadata(spec -> {
+			metadata(spec -> {
 				Address.Builder builder = Address.from(properties.getRouteId());
 				builderConsumer.accept(builder);
 				spec.metadata(builder.build(), MimeTypes.ROUTING_FRAME_MIME_TYPE);

--- a/rsocket-routing-client-spring/src/test/java/io/rsocket/routing/client/spring/RoutingRSocketRequesterTests.java
+++ b/rsocket-routing-client-spring/src/test/java/io/rsocket/routing/client/spring/RoutingRSocketRequesterTests.java
@@ -16,6 +16,14 @@
 
 package io.rsocket.routing.client.spring;
 
+import static io.rsocket.routing.client.spring.RoutingRSocketRequester.address;
+import static io.rsocket.routing.client.spring.RoutingRSocketRequester.expand;
+import static io.rsocket.routing.common.WellKnownKey.ROUTE_ID;
+import static io.rsocket.routing.common.WellKnownKey.SERVICE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,15 +34,12 @@ import io.rsocket.routing.common.Tags;
 import io.rsocket.routing.frames.Address;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.messaging.rsocket.RSocketRequester;
+import org.springframework.messaging.rsocket.RSocketRequester.RequestSpec;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.RouteMatcher;
 import org.springframework.util.SimpleRouteMatcher;
 
-import static io.rsocket.routing.client.spring.RoutingRSocketRequester.address;
-import static io.rsocket.routing.client.spring.RoutingRSocketRequester.expand;
-import static io.rsocket.routing.common.WellKnownKey.ROUTE_ID;
-import static io.rsocket.routing.common.WellKnownKey.SERVICE_NAME;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class RoutingRSocketRequesterTests {
 
@@ -104,6 +109,21 @@ public class RoutingRSocketRequesterTests {
 	public void expandWithMismatchedCurlyBraces() {
 		String result = expand("/myurl/{{{{", Collections.emptyMap());
 		assertThat(result).isEqualTo("/myurl/{{{{");
+	}
+	
+	@Test
+	public void routeWithAddress() {
+		RequestSpec spec = mock(RequestSpec.class);
+		RSocketRequester requester = mock(RSocketRequester.class);
+		when(requester.route("route")).thenReturn(spec);
+		RoutingClientProperties properties = new RoutingClientProperties();
+		RouteMatcher routeMatcher = mock(RouteMatcher.class);
+		
+		RoutingRSocketRequester routingRSocketRequester = new RoutingRSocketRequester(requester, properties, routeMatcher);
+		routingRSocketRequester
+			.route("route")
+			.address("service")
+			.send();
 	}
 
 }


### PR DESCRIPTION
The address(...) methods in RoutingRequestSpec now not just delegate to the delegate Object but also update the hasRoutingMetadata flag.